### PR TITLE
#4 content passed to sha1_hex needs to be encoded as UTF-8

### DIFF
--- a/lib/font-optimizer/Font/Subsetter.pm
+++ b/lib/font-optimizer/Font/Subsetter.pm
@@ -1493,7 +1493,7 @@ sub subset {
 
     $self->{features} = $options->{features};
 
-    my $uid = substr(sha1_hex("$filename $chars"), 0, 16);
+    my $uid = substr(sha1_hex(encode_utf8("$filename $chars")), 0, 16);
 
     if (not $self->{font}) {
         $self->preload($filename);


### PR DESCRIPTION
This encodes the argument passed to the `sh1_hash` call as UTF-8 which prevents that call from throwing an exception. I believe there is still and issue where if `$chars` contains non UTF-8 characters they will not be removed from the font. 